### PR TITLE
feat: add CURLOPT_XFERINFOFUNCTION

### DIFF
--- a/YMHTTP/Classes/YMURLSessionTask.m
+++ b/YMHTTP/Classes/YMURLSessionTask.m
@@ -1660,6 +1660,16 @@ typedef NS_ENUM(NSUInteger, YMURLSessionTaskProtocolState) {
     [self.session updateTimeoutTimerToValue:value];
 }
 
+- (void)updateProgressMeterWithTotalBytesSent:(int64_t)totalBytesSent
+                     totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
+                           totalBytesReceived:(int64_t)totalBytesReceived
+                  totalBytesExpectedToReceive:(int64_t)totalBytesExpectedToReceive {
+    if (!self.progress) return;
+
+    self.progress.totalUnitCount = totalBytesExpectedToReceive + totalBytesExpectedToSend;
+    self.progress.completedUnitCount = totalBytesReceived + totalBytesSent;
+}
+
 #pragma mark - Headers Methods
 
 - (NSDictionary *)transformLowercaseKeyForHTTPHeaders:(NSDictionary *)HTTPHeaders {

--- a/YMHTTP/Classes/curl/YMEasyHandle.h
+++ b/YMHTTP/Classes/curl/YMEasyHandle.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)needTimeoutTimerToValue:(NSInteger)value;
 
+- (void)updateProgressMeterWithTotalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend totalBytesReceived:(int64_t)totalBytesReceived totalBytesExpectedToReceive:(int64_t)totalBytesExpectedToReceive;
+
 @end
 
 typedef void *YMURLSessionEasyHandle;

--- a/YMHTTP/Classes/curl/YMEasyHandle.m
+++ b/YMHTTP/Classes/curl/YMEasyHandle.m
@@ -78,7 +78,12 @@ typedef NS_OPTIONS(NSUInteger, YMEasyHandlePauseState) {
 
     // seeking in input stream
     YM_ECODE(curl_easy_setopt(self.rawHandle, CURLOPT_SEEKDATA, (__bridge void *)self));
-    YM_ECODE(curl_easy_setopt(self.rawHandle, CURLOPT_SEEKFUNCTION, (__bridge void *)self));
+    YM_ECODE(curl_easy_setopt(self.rawHandle, CURLOPT_SEEKFUNCTION, _curl_seek_function));
+    
+    // progress
+    YM_ECODE(curl_easy_setopt(self.rawHandle, CURLOPT_NOPROGRESS, 0));
+    YM_ECODE(curl_easy_setopt(self.rawHandle, CURLOPT_PROGRESSDATA, (__bridge void *)self));
+    YM_ECODE(curl_easy_setopt(self.rawHandle, CURLOPT_XFERINFOFUNCTION, _curl_XFERINFO_function));
 }
 
 #pragma mark - Public Methods
@@ -444,6 +449,13 @@ int _curl_seek_function(void *userdata, curl_off_t offset, int origin) {
     YMEasyHandle *handle = from(userdata);
     if (!handle) return CURL_SEEKFUNC_FAIL;
     return [handle seekInputStreamWithOffset:offset origin:origin];
+}
+
+int _curl_XFERINFO_function(void *userdata, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal,  curl_off_t ulnow) {
+    YMEasyHandle *handle = from(userdata);
+    if (!handle) return -1;
+    [handle.delegate updateProgressMeterWithTotalBytesSent:ulnow totalBytesExpectedToSend:ultotal totalBytesReceived:dlnow totalBytesExpectedToReceive:dltotal];
+    return 0;
 }
 
 int _curl_debug_function(CURL *handle, curl_infotype type, char *data, size_t size, void *userptr) {


### PR DESCRIPTION
It is still partly functional: it starts out as indeterminate, can report certain kind of upload progresses, will be set as done correctly when the task terminates, and its .cancel() method will cancel the task as usual.