### PR TITLE
fix: doesn't add Content-Length to empty body requests

### DIFF
--- a/Example/Tests/YMHTTPUploadDelegate.h
+++ b/Example/Tests/YMHTTPUploadDelegate.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface YMHTTPUploadDelegate : XCTestCase <YMURLSessionDataDelegate>
 
+@property (nonnull, nonatomic, strong) NSMutableArray *callbacks;
 @property (nonnull, nonatomic, strong) XCTestExpectation *uploadCompletedExpectation;
 @property (nonnull, nonatomic, strong) NSInputStream *streamToProvideOnRequest;
 @property int64_t totalBytesSent;

--- a/Example/Tests/YMHTTPUploadDelegate.m
+++ b/Example/Tests/YMHTTPUploadDelegate.m
@@ -10,17 +10,30 @@
 
 @implementation YMHTTPUploadDelegate
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.callbacks = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
 - (void)YMURLSession:(YMURLSession *)session
                         task:(YMURLSessionTask *)task
              didSendBodyData:(int64_t)bytesSent
               totalBytesSent:(int64_t)totalBytesSent
     totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
+    NSString *last = (NSString *)self.callbacks.lastObject;
+    if (![last isEqualToString:NSStringFromSelector(_cmd)]) {
+        [self.callbacks addObject:NSStringFromSelector(_cmd)];
+    }
     self.totalBytesSent = totalBytesSent;
 }
 
 - (void)YMURLSession:(YMURLSession *)session
                  task:(YMURLSessionTask *)task
     needNewBodyStream:(void (^)(NSInputStream *_Nullable))completionHandler {
+    [self.callbacks addObject:NSStringFromSelector(_cmd)];
     if (!self.streamToProvideOnRequest) {
         XCTFail(@"This shouldn't have been invoked -- no stream was set.");
     }
@@ -28,6 +41,7 @@
 }
 
 - (void)YMURLSession:(YMURLSession *)session task:(YMURLSessionTask *)task didReceiveData:(NSData *)data {
+    [self.callbacks addObject:NSStringFromSelector(_cmd)];
     XCTAssertEqual(self.totalBytesSent, 1 * 512);
     [self.uploadCompletedExpectation fulfill];
 }


### PR DESCRIPTION
- For all methods except GET, if the request _Body is .none then
  set a length of 0. This will add a "Content-Length: 0" header.

- Fail any GET requests with a body, to match Darwin.