### PR TITLE
fix: Set default Content-Type for POST request

### DIFF
--- a/YMHTTP/YMURLSessionTask.m
+++ b/YMHTTP/YMURLSessionTask.m
@@ -712,8 +712,12 @@ typedef NS_ENUM(NSUInteger, YMURLSessionTaskProtocolState) {
     [hh addEntriesFromDictionary:[self transformLowercaseKeyForHTTPHeaders:HTTPHeaders]];
 
     NSArray *curlHeaders = [self curlHeadersForHTTPHeaders:hh];
-    if ([request.HTTPMethod isEqualToString:@"POST"] && (request.HTTPBody.length > 0) &&
-        ([request valueForHTTPHeaderField:@"Content-Type"] == nil)) {
+    BOOL hasStream = request.HTTPBodyStream != nil;
+    if (self.knownBody.type == YMURLSessionTaskBodyTypeStream) {
+        hasStream = true;
+    }
+    if ([request.HTTPMethod isEqualToString:@"POST"] && ([request valueForHTTPHeaderField:@"Content-Type"] == nil) &&
+        (request.HTTPBody.length > 0 || hasStream)) {
         NSMutableArray *temp = [curlHeaders mutableCopy];
         [temp addObject:@"Content-Type:application/x-www-form-urlencoded"];
         curlHeaders = temp;


### PR DESCRIPTION
If a POST request does not have a Content-Type set and the body has a size greater than zero, then an entry is added to the headers with type application/x-www-form-urlencoded. This was not being done if the body was an InputStream, so add a fix to ensure it is.